### PR TITLE
Fix an issue with iosver.js and iOS 10

### DIFF
--- a/js/iosver.js
+++ b/js/iosver.js
@@ -55,9 +55,9 @@ const VERSION_CHECK_UNSUPPORTED = "Only compatible with iOS %s to %s &#x1f61e;";
 				return 1;
 			}
 
-			if (one[i] == two[i]) {
+			if (Number(one[i]) == Number(two[i])) {
 				continue;
-			} else if (one[i] > two[i]) {
+			} else if (Number(one[i]) > Number(two[i])) {
 				return 1;
 			} else {
 				return -1;


### PR DESCRIPTION
On iOS 10 it would not properly compare the version number and in most cases would result in a VERSION_CHECK_NEEDS_UPGRADE instead of a desired result